### PR TITLE
feat: Update AttachToInvoice to handle multiple delivery notes

### DIFF
--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/AttachToInvoice/AttachToInvoiceCommand.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/AttachToInvoice/AttachToInvoiceCommand.cs
@@ -1,3 +1,3 @@
 ﻿namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.AttachToInvoice;
 
-public record AttachToInvoiceCommand(int InvoiceId, int DeliveryNoteId): IRequest<Result>;
+public record AttachToInvoiceCommand(int InvoiceId, List<int> DeliveryNoteIds) : IRequest<Result>;

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/AttachToInvoice/AttachToInvoiceCommandHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/AttachToInvoice/AttachToInvoiceCommandHandler.cs
@@ -9,9 +9,9 @@ public class AttachToInvoiceCommandHandler(
 {
     public async Task<Result> Handle(AttachToInvoiceCommand attachToInvoiceCommand, CancellationToken cancellationToken)
     {
-        _logger.LogEntityCreated(nameof(BonDeLivraison), attachToInvoiceCommand);
+        _logger.LogInformation("Attempting to attach delivery notes {DeliveryNoteIds} to invoice {InvoiceId}",
+            string.Join(", ", attachToInvoiceCommand.DeliveryNoteIds), attachToInvoiceCommand.InvoiceId);
 
-        // Fetch only the required fields from Facture
         var invoice = await _context.Facture
             .Select(i => new { CustomerId = i.IdClient, NumInvoice = i.Num })
             .FirstOrDefaultAsync(i => i.NumInvoice == attachToInvoiceCommand.InvoiceId, cancellationToken);
@@ -22,48 +22,53 @@ public class AttachToInvoiceCommandHandler(
             return Result.Fail(EntityNotFound.Error);
         }
 
-        // Fetch only the necessary fields from BonDeLivraison to validate
-        var deliveryNote = await _context.BonDeLivraison
-            .Where(d => d.Num == attachToInvoiceCommand.DeliveryNoteId)
-            .Select(d => new { d.NumFacture, d.ClientId })
-            .FirstOrDefaultAsync(cancellationToken);
+        var deliveryNotes = await _context.BonDeLivraison
+            .Where(d => attachToInvoiceCommand.DeliveryNoteIds.Contains(d.Num))
+            .Select(d => new { d.Num, d.NumFacture, d.ClientId })
+            .ToListAsync(cancellationToken);
 
-        if (deliveryNote is null)
+        // Check if all requested delivery notes exist
+        var missingDeliveryNotes = attachToInvoiceCommand.DeliveryNoteIds
+            .Except(deliveryNotes.Select(d => d.Num))
+            .ToList();
+        if (missingDeliveryNotes.Any())
         {
-            _logger.LogEntityNotFound(nameof(BonDeLivraison), attachToInvoiceCommand.DeliveryNoteId);
+            _logger.LogEntityNotFound(nameof(BonDeLivraison), string.Join(", ", missingDeliveryNotes));
             return Result.Fail(EntityNotFound.Error);
         }
 
-        if (deliveryNote.NumFacture.HasValue)
+        // Check if any delivery notes are already attached to an invoice
+        var alreadyAttached = deliveryNotes
+            .Where(d => d.NumFacture.HasValue)
+            .ToList();
+        if (alreadyAttached.Any())
         {
-            _logger.LogWarning("Delivery note with Num {DeliveryNoteId} is already attached to Facture {FactureId}.",
-                attachToInvoiceCommand.DeliveryNoteId, deliveryNote.NumFacture);
+            _logger.LogWarning("Delivery notes {DeliveryNoteIds} are already attached to invoices {FactureIds}",
+                string.Join(", ", alreadyAttached.Select(d => d.Num)),
+                string.Join(", ", alreadyAttached.Select(d => d.NumFacture)));
             return Result.Fail("delivery_note_already_attached");
         }
 
-        if (deliveryNote.ClientId != invoice.CustomerId)
+        // Check if all delivery notes belong to the same customer as the invoice
+        var mismatchedCustomers = deliveryNotes
+            .Where(d => d.ClientId != invoice.CustomerId)
+            .ToList();
+        if (mismatchedCustomers.Any())
         {
-            _logger.LogWarning("Delivery note with Num {DeliveryNoteId} is not for the same client as Facture {FactureId}.",
-                attachToInvoiceCommand.DeliveryNoteId, deliveryNote.NumFacture);
+            _logger.LogWarning("Delivery notes {DeliveryNoteIds} do not match the customer of invoice {InvoiceId}",
+                string.Join(", ", mismatchedCustomers.Select(d => d.Num)), attachToInvoiceCommand.InvoiceId);
             return Result.Fail("customer_invoice_doesnt_match_customer_delivery_note");
         }
 
-        // Perform a direct update without loading the full entity
-        var rowsAffected = await _context.BonDeLivraison
-            .Where(d => d.Num == attachToInvoiceCommand.DeliveryNoteId)
+        await _context.BonDeLivraison
+            .Where(d => attachToInvoiceCommand.DeliveryNoteIds.Contains(d.Num))
             .ExecuteUpdateAsync(
                 updates => updates.SetProperty(d => d.NumFacture, attachToInvoiceCommand.InvoiceId),
                 cancellationToken);
 
-        if (rowsAffected == 0)
-        {
-            _logger.LogError("Failed to update delivery note {DeliveryNoteId}.", attachToInvoiceCommand.DeliveryNoteId);
-            return Result.Fail("update_failed");
-        }
-
         await _context.SaveChangesAsync(cancellationToken);
-        _logger.LogInformation("Attached delivery note {DeliveryNoteId} to facture {FactureId}.",
-            attachToInvoiceCommand.DeliveryNoteId, attachToInvoiceCommand.InvoiceId);
+        _logger.LogInformation("Successfully attached delivery notes {DeliveryNoteIds} to invoice {InvoiceId}",
+            string.Join(", ", attachToInvoiceCommand.DeliveryNoteIds), attachToInvoiceCommand.InvoiceId);
 
         return Result.Ok();
     }

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/AttachToInvoice/AttachToInvoiceEndpoint.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/AttachToInvoice/AttachToInvoiceEndpoint.cs
@@ -11,7 +11,7 @@ public class AttachToInvoiceEndpoint : ICarterModule
                 [FromBody] AttachToInvoiceRequest attachToInvoiceRequest,
                 CancellationToken cancellationToken) =>
             {
-                var command = new AttachToInvoiceCommand(attachToInvoiceRequest.InvoiceId, attachToInvoiceRequest.DeliveryNoteId);
+                var command = new AttachToInvoiceCommand(attachToInvoiceRequest.InvoiceId, attachToInvoiceRequest.DeliveryNoteIds);
                 var attachToInvoiceResult = await mediator.Send(command);
 
                 if (attachToInvoiceResult.HasError<EntityNotFound>())

--- a/src/TunNetCom.SilkRoadErp.Sales.Contracts/DeliveryNote/AttachToInvoiceRequest.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Contracts/DeliveryNote/AttachToInvoiceRequest.cs
@@ -8,5 +8,5 @@ public class AttachToInvoiceRequest
     public int InvoiceId { get; set; }
 
     [JsonPropertyName("BonDeLivraisonId")]
-    public int DeliveryNoteId { get; set; }
+    public List<int> DeliveryNoteIds { get; set; }
 }

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/CreateCustomerCommandHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/CreateCustomerCommandHandlerTests.cs
@@ -1,4 +1,7 @@
-﻿namespace TunNetCom.SilkRoadErp.Sales.UnitTests.Tests.Customers;
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+
+namespace TunNetCom.SilkRoadErp.Sales.UnitTests.Tests.Customers;
 
 public class CreateCustomerCommandHandlerTests
 {
@@ -8,11 +11,13 @@ public class CreateCustomerCommandHandlerTests
 
     public CreateCustomerCommandHandlerTests()
     {
+        //UseInMemoryDatabase for isolated, fast testing without hitting a real database.
         var options = new DbContextOptionsBuilder<SalesContext>()
             .UseInMemoryDatabase(databaseName: "SalesContext")
-            .Options;
+        .Options;
 
         _context = new SalesContext(options);
+        //Creates a TestLogger instance to mock logging behavior.
         _testLogger = new TestLogger<CreateCustomerCommandHandler>();
         _createCustomerCommandHandler = new CreateCustomerCommandHandler(_context, _testLogger);
     }


### PR DESCRIPTION
- Modified AttachToInvoiceCommand to accept List<int> DeliveryNoteIds.
- Updated AttachToInvoiceCommandHandler to process multiple delivery notes with checks for existence, attachment status, and customer matching.
- Adjusted logging for clarity with multiple IDs.
- Updated AttachToInvoiceEndpoint and AttachToInvoiceRequest to align with the new command.
- Minor clarity updates to CreateCustomerCommandHandlerTests.
- Tested with Swagger and debugged to ensure correct behavior.