### PR TITLE
Rename "Customer" to "Client" in test classes

### DIFF
--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/CreateCustomerCommandHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/CreateCustomerCommandHandlerTests.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
-
-namespace TunNetCom.SilkRoadErp.Sales.UnitTests.Tests.Customers;
+﻿namespace TunNetCom.SilkRoadErp.Sales.UnitTests.Tests.Customers;
 
 public class CreateCustomerCommandHandlerTests
 {
@@ -96,7 +93,7 @@ public class CreateCustomerCommandHandlerTests
         await _createCustomerCommandHandler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.Contains(_testLogger.Logs, log => log.Contains($"Creating customer with values: {command}"));
+        Assert.Contains(_testLogger.Logs, log => log.Contains($"Creating {nameof(Client)} with values: {command}"));
     }
 
     [Fact]
@@ -129,6 +126,8 @@ public class CreateCustomerCommandHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess, "Expected operation to succeed");
-        Assert.Contains(_testLogger.Logs, log => log.Contains($"Customer created successfully with ID: {result.Value}"));
+        Assert.Contains(
+            _testLogger.Logs,
+            log => log.Contains($"{nameof(Client)} created successfully with ID: {result.Value}"));
     }
 }

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/DeleteCustomerCommandHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/DeleteCustomerCommandHandlerTests.cs
@@ -27,8 +27,8 @@ public class DeleteCustomerCommandHandlerTests
 
         // Assert
         Assert.False(result.IsSuccess);
-        Assert.Equal("Customer_Not_Found", result.Errors.First().Message);
-        Assert.Contains(_testLogger.Logs, log => log.Contains($"Customer with ID: {command} not found"));
+        Assert.Equal("client_not_found", result.Errors.First().Message);
+        Assert.Contains(_testLogger.Logs, log => log.Contains($"{nameof(Client)} with ID: {command.Id} not found"));
 
     }
 
@@ -84,6 +84,8 @@ public class DeleteCustomerCommandHandlerTests
         var result = await _deleteCustomerCommandHandler.Handle(command, CancellationToken.None);
 
         // Assert
-        Assert.Contains(_testLogger.Logs, log => log.Contains($"Delete customer with values: {command}"));
+        Assert.Contains(
+            _testLogger.Logs,
+            log => log.Contains($"{nameof(Client)} with ID: {command.Id} deleted successfully"));
     }
 }

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/GetCustomerByidQueryHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/GetCustomerByidQueryHandlerTests.cs
@@ -73,6 +73,6 @@ public class GetCustomerByidQueryHandlerTests
         var result = await _getCustomerByIdQueryHandler.Handle(query, CancellationToken.None);
 
         // Assert
-        Assert.Contains(_testLogger.Logs, log => log.Contains($"customer with ID: {query.Id} not found"));
+        Assert.Contains(_testLogger.Logs, log => log.Contains($"{nameof(Client)} with ID: {query.Id} not found"));
     }
 }

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/GetCustomerQueryHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/GetCustomerQueryHandlerTests.cs
@@ -31,7 +31,11 @@ public class GetCustomerQueryHandlerTests
         var result = await _getCustomerQueryHandler.Handle(query, CancellationToken.None);
 
         // Assert
-        Assert.Contains(_testLogger.Logs, log => log.Contains($"Fetching customers with pageIndex: {query.PageNumber} and pageSize: {query.PageSize}"));
+        Assert.Contains(
+            _testLogger.Logs,
+            log => log.Contains(
+                $"Fetching {nameof(Client)} with pageIndex: {query.PageNumber} and pageSize: {query.PageSize}"));
+
         Assert.NotNull(result);
     }
 
@@ -41,13 +45,13 @@ public class GetCustomerQueryHandlerTests
         // Arrange
         var client = Client.CreateClient
             (
-             nom: "Client tojrab",
+             nom: "Client test",
              tel: "1234567898",
-             adresse: "houni much baid",
-             matricule: "Matricule",
-             code: "Code",
-             codeCat: "CodeCat",
-             etbSec: "EtbSec",
+             adresse: "paris",
+             matricule: "12345/B",
+             code: "A",
+             codeCat: "C",
+             etbSec: "000",
              mail: "email@example.com");
 
         _context.Client.Add(client);
@@ -56,7 +60,7 @@ public class GetCustomerQueryHandlerTests
         var query = new GetCustomerQuery(
            PageNumber: 1,
            PageSize: 10,
-           SearchKeyword: "Client tojrab"
+           SearchKeyword: "Client test"
        );
 
         // Act
@@ -64,7 +68,7 @@ public class GetCustomerQueryHandlerTests
 
         // Assert
         Assert.Single(result);
-        Assert.Equal("Client tojrab", result.First().Nom);
+        Assert.Equal("Client test", result.First().Nom);
     }
 
     [Fact]
@@ -73,37 +77,38 @@ public class GetCustomerQueryHandlerTests
         // Arrange
         var client1 = Client.CreateClient
             (
-             nom: "Client tojrab1",
+             nom: "Client test",
              tel: "1234567898",
-             adresse: "houni much baid",
-             matricule: "Matricule",
-             code: "Code",
-             codeCat: "CodeCat",
-             etbSec: "EtbSec",
+             adresse: "paris",
+             matricule: "12345/B",
+             code: "A",
+             codeCat: "C",
+             etbSec: "000",
              mail: "email@example.com");
 
         var client2 = Client.CreateClient
             (
-             nom: "Client tojrab2",
+             nom: "Client test 2",
              tel: "1234567898",
-             adresse: "houni much baid",
-             matricule: "Matricule",
-             code: "Code",
-             codeCat: "CodeCat",
-             etbSec: "EtbSec",
+             adresse: "paris",
+             matricule: "12345/B",
+             code: "A",
+             codeCat: "C",
+             etbSec: "000",
              mail: "email@example.com");
 
         var client3 = Client.CreateClient
             (
-             nom: "Client tojrab3",
+             nom: "Client test 3",
              tel: "1234567898",
-             adresse: "houni much baid",
-             matricule: "Matricule",
-             code: "Code",
-             codeCat: "CodeCat",
-             etbSec: "EtbSec",
+             adresse: "paris",
+             matricule: "12345/B",
+             code: "A",
+             codeCat: "C",
+             etbSec: "000",
              mail: "email@example.com");
-        _context.Client.AddRange(client1,client2,client3);
+
+        _context.Client.AddRange(client1, client2, client3);
         await _context.SaveChangesAsync();
         var query = new GetCustomerQuery(
             PageNumber: 1,

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/UpdateCustomerCommandHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/UpdateCustomerCommandHandlerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection.Metadata;
-using TunNetCom.SilkRoadErp.Sales.Api.Features.Customers.UpdateCustomer;
+﻿using TunNetCom.SilkRoadErp.Sales.Api.Features.Customers.UpdateCustomer;
 
 namespace TunNetCom.SilkRoadErp.Sales.UnitTests.Tests.Customers;
 
@@ -39,8 +38,12 @@ public class UpdateCustomerCommandHandlerTests
 
         // Assert
         Assert.False(result.IsSuccess);
+
         Assert.Equal("not_found", result.Errors.First().Message);
-        Assert.Contains(_testLogger.Logs, log => log.Contains("Customer not found with ID: 1"));
+
+        Assert.Contains(
+            _testLogger.Logs,
+            log => log.Contains($"{nameof(Client)} with ID: {command.Id} not found"));
     }
 
     [Fact]
@@ -112,6 +115,8 @@ public class UpdateCustomerCommandHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Contains(_testLogger.Logs, log => log.Contains($"Customer updated with ID: {existingCustomer.Id} updated successfully"));
+        Assert.Contains(
+            _testLogger.Logs,
+            log => log.Contains($"{nameof(Client)} with ID: {existingCustomer.Id} updated successfully"));
     }
 }


### PR DESCRIPTION
Updated log messages, assertions, and test data across
various test classes to reflect the new terminology of
"Client" instead of "Customer". This ensures consistency
in naming conventions throughout the application.