### PR TITLE
Update assertions in query handler tests #85

### DIFF
--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/GetCustomerQueryHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Customers/GetCustomerQueryHandlerTests.cs
@@ -120,6 +120,6 @@ public class GetCustomerQueryHandlerTests
         var result = await _getCustomerQueryHandler.Handle(query, CancellationToken.None);
 
         // Assert
-        Assert.True(result.Count > 3);
+        Assert.True(result.Count >= 3);
     }
 }

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Products/GetProductQueryHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Products/GetProductQueryHandlerTests.cs
@@ -130,6 +130,6 @@ public class GetProductQueryHandlerTests
 
         // Assert
         //TODO : Change the logic
-        Assert.True(result.Count > 3);
+        Assert.True(result.Count >= 3);
     }
 }

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Providers/GetProviderQueryHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/Providers/GetProviderQueryHandlerTests.cs
@@ -112,6 +112,6 @@ public class GetProviderQueryHandlerTests
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert
-        Assert.True(result.Count > 2);
+        Assert.True(result.Count >= 2);
     }
 }

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/ReceiptNotes/GetReceiptNoteQueryHandlerTests.cs
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/Tests/ReceiptNotes/GetReceiptNoteQueryHandlerTests.cs
@@ -71,6 +71,6 @@ public class GetReceiptNoteQueryHandlerTests
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert
-        Assert.True(result.Count > 2);
+        Assert.True(result.Count >= 2);
     }
 }


### PR DESCRIPTION
Modified assertion conditions in the tests for `GetCustomerQueryHandler`, `GetProductQueryHandler`, `GetProviderQueryHandler`, and `GetReceiptNoteQueryHandler` to check for greater than or equal to the specified count instead of just greater than. This change enhances the accuracy of the tests.

