### PR TITLE
Add code coverage settings to test.runsettings https://github.com/TunNetCom/TunNetCom-SilkRoadErp/issues/85 #85

### DIFF
--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/test.runsettings
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/test.runsettings
@@ -1,0 +1,15 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage">
+        <Configuration>
+          <Exclude>
+            <Module>moq.dll</Module>
+            <Module>*.Test.dll</Module> <!-- Exclude test projects if needed -->
+            <Module>*.Tests.dll</Module> <!-- Exclude test projects if named like this -->
+          </Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
This commit introduces a new `<RunSettings>` configuration in the `test.runsettings` file. It includes a `<DataCollectionRunSettings>` section that specifies a `<DataCollector>` for "Code Coverage." The configuration excludes `moq.dll`, as well as any test projects ending with `.Test.dll` and `.Tests.dll` from coverage analysis.