### PR TITLE
Add test.runsettings to project file https://github.com/TunNetCom/TunNetCom-SilkRoadErp/issues/85 #85

### DIFF
--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/TunNetCom.SilkRoadErp.Sales.UnitTests.csproj
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/TunNetCom.SilkRoadErp.Sales.UnitTests.csproj
@@ -28,4 +28,10 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="test.runsettings">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION

Added a new `<ItemGroup>` to the project file that includes a `<None>` element for `test.runsettings`, ensuring it is always copied to the output directory.