### PR TITLE
Update code coverage exclusions in runsettings #85

### DIFF
--- a/test.runsettings
+++ b/test.runsettings
@@ -4,6 +4,7 @@
       <DataCollector friendlyName="Code Coverage">
         <Configuration>
           <Exclude>
+            <Module>FluentValidation.dll</Module>
             <Module>Moq.dll</Module>
             <Module>*.Test.dll</Module> <!-- Exclude test projects if needed -->
             <Module>*.Tests.dll</Module> <!-- Exclude test projects if named like this -->


### PR DESCRIPTION
Update code coverage exclusions in runsettings #85

Updated the `test.runsettings` file to exclude specific modules from code coverage analysis. The exclusions now include `FluentValidation.dll`, `Moq.dll`, and any DLLs matching the patterns `*.Test.dll` and `*.Tests.dll`, allowing for more accurate coverage metrics focused on the main application code.

