### PR TITLE
Enhance code coverage settings and reporting tools #85

### DIFF
--- a/test.runsettings
+++ b/test.runsettings
@@ -5,6 +5,7 @@
         <Configuration>
           <Exclude>
             <Module>FluentValidation.dll</Module>
+            <Module>FluentValidation.*.dll</Module>
             <Module>Moq.dll</Module>
             <Module>*.Test.dll</Module> <!-- Exclude test projects if needed -->
             <Module>*.Tests.dll</Module> <!-- Exclude test projects if named like this -->

--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/TunNetCom.SilkRoadErp.Sales.UnitTests.csproj
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/TunNetCom.SilkRoadErp.Sales.UnitTests.csproj
@@ -17,6 +17,9 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+	<PackageReference Include="coverlet.collector" Version="3.2.0" />
+	<PackageReference Include="coverlet.msbuild" Version="3.2.0" />
+	<PackageReference Include="ReportGenerator" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Enhance code coverage settings and reporting tools #85

Updated `test.runsettings` to exclude additional DLLs 
from code coverage. Added `coverlet.collector`, 
`coverlet.msbuild`, and `ReportGenerator` package 
references to improve code coverage reporting in 
unit tests.

