### PR TITLE
Update test.runsettings to exclude fluentvalidation modules #85

### DIFF
--- a/test.runsettings
+++ b/test.runsettings
@@ -4,10 +4,10 @@
       <DataCollector friendlyName="Code Coverage">
         <Configuration>
           <Exclude>
-            <Module>.*fluentvalidation.*</Module>
             <Module>Moq.dll</Module>
             <Module>*.Test.dll</Module> <!-- Exclude test projects if needed -->
             <Module>*.Tests.dll</Module> <!-- Exclude test projects if named like this -->
+            <Module>.*fluentvalidation.*</Module>
           </Exclude>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
Update test.runsettings to exclude fluentvalidation modules #85

Added exclusion for modules matching the pattern `.*fluentvalidation.*` in the Code Coverage configuration to improve coverage analysis accuracy.

