### PR TITLE
Update test.runsettings to include FluentValidation modules #85

### DIFF
--- a/test.runsettings
+++ b/test.runsettings
@@ -8,6 +8,8 @@
             <Module>*.Test.dll</Module> <!-- Exclude test projects if needed -->
             <Module>*.Tests.dll</Module> <!-- Exclude test projects if named like this -->
             <Module>.*fluentvalidation.*</Module>
+            <Module>FluentValidation.dll</Module>
+            <Module>bin\**\FluentValidation.dll</Module>
           </Exclude>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
Update test.runsettings to include FluentValidation modules #85

Added `<Module>` entries for `FluentValidation.dll` and 
`bin\**\FluentValidation.dll` to the test run settings, 
ensuring the FluentValidation library is included while 
maintaining existing exclusions for other modules.

