### PR TITLE
Remove code coverage and reporting packages #85

### DIFF
--- a/test/TunNetCom.SilkRoadErp.Sales.UnitTests/TunNetCom.SilkRoadErp.Sales.UnitTests.csproj
+++ b/test/TunNetCom.SilkRoadErp.Sales.UnitTests/TunNetCom.SilkRoadErp.Sales.UnitTests.csproj
@@ -17,9 +17,6 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-	<PackageReference Include="coverlet.collector" Version="3.2.0" />
-	<PackageReference Include="coverlet.msbuild" Version="3.2.0" />
-	<PackageReference Include="ReportGenerator" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove code coverage and reporting packages #85

Removed `coverlet.collector`, `coverlet.msbuild`, and `ReportGenerator` from `TunNetCom.SilkRoadErp.Sales.UnitTests.csproj`. This change reflects a potential shift in the project's testing and code coverage strategy.

