### PR TITLE
Update pagination handling and logging for delivery notes #97 

### DIFF
--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Customers/GetCustomer/GetCustomerQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Customers/GetCustomer/GetCustomerQueryHandler.cs
@@ -45,7 +45,7 @@ public class GetCustomerQueryHandler(
             cancellationToken);
 
 
-        _logger.LogEntitiesFetched(nameof(Client), pagedCustomers.Count);
+        _logger.LogEntitiesFetched(nameof(Client), pagedCustomers.Items.Count);
 
         return pagedCustomers;
     }

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNote/GetDeliveryNoteQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNote/GetDeliveryNoteQueryHandler.cs
@@ -43,7 +43,7 @@ public class GetDeliveryNoteQueryHandler(
             cancellationToken);
 
 
-        _logger.LogEntitiesFetched(nameof(BonDeLivraison), pagedDeliveryNote.Count);
+        _logger.LogEntitiesFetched(nameof(BonDeLivraison), pagedDeliveryNote.Items.Count);
 
         return pagedDeliveryNote;
     }

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesBaseInfosWithSummaries/GetDeliveryNotesBaseInfosWithSummariesQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesBaseInfosWithSummaries/GetDeliveryNotesBaseInfosWithSummariesQueryHandler.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Data.SqlClient;
-using TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNote;
+﻿using TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNote;
 using TunNetCom.SilkRoadErp.Sales.Contracts.DeliveryNote.Responses;
+
 namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNotesBaseInfosWithSummaries;
 
 public class GetDeliveryNotesBaseInfosWithSummariesQueryHandler(
@@ -37,12 +37,15 @@ public class GetDeliveryNotesBaseInfosWithSummariesQueryHandler(
         {
             deliveryNoteQuery = deliveryNoteQuery.Where(d => d.NumFacture == null);
         }
+
         if(request.SortOrder != null && request.SortProperty != null)
         {
             _logger.LogInformation("sorting delivery notes column : {column} order : {order}", request.SortProperty, request.SortOrder);
             deliveryNoteQuery = ApplySorting(deliveryNoteQuery, request.SortProperty, request.SortOrder);
         }
+
         _logger.LogInformation("Getting Gross, Vat and Net amounts");
+
         var totalGrossAmount = await deliveryNoteQuery.SumAsync(d => d.GrossAmount, cancellationToken);
         var totalVATAmount = await deliveryNoteQuery.SumAsync(d => d.VatAmount, cancellationToken);
         var totalNetAmount = await deliveryNoteQuery.SumAsync(d => d.NetAmount, cancellationToken);
@@ -62,18 +65,25 @@ public class GetDeliveryNotesBaseInfosWithSummariesQueryHandler(
         };
 
 
-        _logger.LogEntitiesFetched(nameof(BonDeLivraison), pagedDeliveryNote.Count);
+        _logger.LogEntitiesFetched(nameof(BonDeLivraison), pagedDeliveryNote.Items.Count);
 
         return getDeliveryNotesWithSummariesResponse;
     }
 
-    private IQueryable<GetDeliveryNoteBaseInfos> ApplySorting(IQueryable<GetDeliveryNoteBaseInfos> deliveryNoteQuery, string sortProperty, string sortOrder)
+    private IQueryable<GetDeliveryNoteBaseInfos> ApplySorting(
+        IQueryable<GetDeliveryNoteBaseInfos> deliveryNoteQuery,
+        string sortProperty,
+        string sortOrder)
     {
         return SortQuery(deliveryNoteQuery, sortProperty, sortOrder.ToLower());
     }
 
-    private IQueryable<GetDeliveryNoteBaseInfos> SortQuery(IQueryable<GetDeliveryNoteBaseInfos> query, string property, string order)
+    private IQueryable<GetDeliveryNoteBaseInfos> SortQuery(
+        IQueryable<GetDeliveryNoteBaseInfos> query,
+        string property,
+        string order)
     {
+        // TODO move magic strings to constants
         return (property, order) switch
         {
             ("Num", "ascending") => query.OrderBy(d => d.Num),

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesBaseInfosWithSummaries/GetDeliveryNotesWithSummariesEndpoint.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesBaseInfosWithSummaries/GetDeliveryNotesWithSummariesEndpoint.cs
@@ -27,7 +27,7 @@ public class GetDeliveryNotesWithSummariesEndpoint : ICarterModule
 
             var response = await mediator.Send(query, cancellationToken);
 
-            if (!response.GetDeliveryNoteBaseInfos.Any())
+            if (!response.GetDeliveryNoteBaseInfos.Items.Any())
             {
                 // TODO: Add a localized message or check this logic
                 return TypedResults.NotFound(new ProblemDetails

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesByInvoiceId/GetDeliveryNotesByInvoiceIdEndpoint.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesByInvoiceId/GetDeliveryNotesByInvoiceIdEndpoint.cs
@@ -1,6 +1,6 @@
 ﻿using TunNetCom.SilkRoadErp.Sales.Contracts.DeliveryNote.Responses;
 
-namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNoteByInvoiceId;
+namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNotesByInvoiceId;
 
 public class GetDeliveryNotesByInvoiceIdEndpoint : ICarterModule
 {

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesByInvoiceId/GetDeliveryNotesByInvoiceIdQuery.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesByInvoiceId/GetDeliveryNotesByInvoiceIdQuery.cs
@@ -1,5 +1,5 @@
 ﻿using TunNetCom.SilkRoadErp.Sales.Contracts.DeliveryNote.Responses;
 
-namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNoteByInvoiceId;
+namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNotesByInvoiceId;
 
 public record GetDeliveryNotesByInvoiceIdQuery (int NumFacture) : IRequest<Result<List<DeliveryNoteResponse>>>;

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesByInvoiceId/GetDeliveryNotesByInvoiceIdQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/DeliveryNote/GetDeliveryNotesByInvoiceId/GetDeliveryNotesByInvoiceIdQueryHandler.cs
@@ -1,6 +1,6 @@
 ﻿using TunNetCom.SilkRoadErp.Sales.Contracts.DeliveryNote.Responses;
 
-namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNoteByInvoiceId;
+namespace TunNetCom.SilkRoadErp.Sales.Api.Features.DeliveryNote.GetDeliveryNotesByInvoiceId;
 
 public class GetDeliveryNotesByInvoiceIdQueryHandler(
     SalesContext _context,

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Invoices/GetInvoicesByCustomerWithSummary/GetInvoicesByCustomerWithSummaryEndpoint.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Invoices/GetInvoicesByCustomerWithSummary/GetInvoicesByCustomerWithSummaryEndpoint.cs
@@ -1,4 +1,4 @@
-﻿namespace TunNetCom.SilkRoadErp.Sales.Api.Features.Invoices.GetInvoicesByCustomer;
+﻿namespace TunNetCom.SilkRoadErp.Sales.Api.Features.Invoices.GetInvoicesByCustomerWithSummary;
 
 public class GetInvoicesByCustomerWithSummaryEndpoint : ICarterModule
 {

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Invoices/GetInvoicesByCustomerWithSummary/GetInvoicesByCustomerWithSummaryQuery.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Invoices/GetInvoicesByCustomerWithSummary/GetInvoicesByCustomerWithSummaryQuery.cs
@@ -1,4 +1,4 @@
-﻿namespace TunNetCom.SilkRoadErp.Sales.Api.Features.Invoices.GetInvoicesByCustomer;
+﻿namespace TunNetCom.SilkRoadErp.Sales.Api.Features.Invoices.GetInvoicesByCustomerWithSummary;
 
 public record GetInvoicesByCustomerWithSummaryQuery(
         int ClientId,

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Invoices/GetInvoicesByCustomerWithSummary/GetInvoicesByCustomerWithSummaryQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Invoices/GetInvoicesByCustomerWithSummary/GetInvoicesByCustomerWithSummaryQueryHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace TunNetCom.SilkRoadErp.Sales.Api.Features.Invoices.GetInvoicesByCustomer;
+﻿namespace TunNetCom.SilkRoadErp.Sales.Api.Features.Invoices.GetInvoicesByCustomerWithSummary;
 
 public class GetInvoicesByCustomerWithSummaryQueryHandler(
     SalesContext _context)
@@ -22,8 +22,11 @@ public class GetInvoicesByCustomerWithSummaryQueryHandler(
                 TotTTC = f.BonDeLivraison.Sum(d => d.NetPayer) + 1000
             });
 
-        var pagedInvoices = await PagedList<InvoiceResponse>
-            .ToPagedListAsync(invoicesQuery, query.PageNumber, query.PageSize, cancellationToken);
+        var pagedInvoices = await PagedList<InvoiceResponse>.ToPagedListAsync(
+            source: invoicesQuery,
+            pageNumber: query.PageNumber,
+            pageSize: query.PageSize,
+            cancellationToken: cancellationToken);
 
         var totalGrossAmount = await invoicesQueryBase.SumAsync(d => d.BonDeLivraison.Sum(d => d.TotHTva));
         var totalVATAmount = await invoicesQueryBase.SumAsync(d => d.BonDeLivraison.Sum(d => d.TotTva));

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Products/GetProduct/GetProductQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Products/GetProduct/GetProductQueryHandler.cs
@@ -35,7 +35,7 @@ public class GetProductQueryHandler(
             getProductQuery.PageSize,
             cancellationToken);
 
-        _logger.LogEntitiesFetched(nameof(Produit), pagedProducts.Count);
+        _logger.LogEntitiesFetched(nameof(Produit), pagedProducts.Items.Count);
 
         return pagedProducts;
 

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Providers/GetProvider/GetProviderQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Providers/GetProvider/GetProviderQueryHandler.cs
@@ -45,7 +45,7 @@ public class GetProviderQueryHandler(SalesContext _context, ILogger<GetProviderQ
             getProviderQuery.PageSize,
             cancellationToken);
 
-        _logger.LogEntitiesFetched(nameof(Fournisseur), pagedProviders.Count);
+        _logger.LogEntitiesFetched(nameof(Fournisseur), pagedProviders.Items.Count);
         return pagedProviders;
     }
 }

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/ReceiptNote/GetReceiptNote/GetReceiptNoteQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/ReceiptNote/GetReceiptNote/GetReceiptNoteQueryHandler.cs
@@ -38,7 +38,7 @@ public class GetReceiptNoteQueryHandler(SalesContext _context, ILogger<GetReceip
             getReceiptNoteQuery.PageSize,
             cancellationToken);
 
-        _logger.LogEntitiesFetched(nameof(BonDeReception), pagedReceipts.Count);
+        _logger.LogEntitiesFetched(nameof(BonDeReception), pagedReceipts.Items.Count);
         return pagedReceipts;
     }
 }

--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/priceQuote/GetPriceQuote/GetPriceQuoteQueryHandler.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/priceQuote/GetPriceQuote/GetPriceQuoteQueryHandler.cs
@@ -41,7 +41,7 @@ namespace TunNetCom.SilkRoadErp.Sales.Api.Features.priceQuote.GetPriceQuote
                 getPriceQuoteQuery.PageSize,
                 cancellationToken);
 
-            _logger.LogEntitiesFetched(nameof(Devis), pagedQuotations.Count);
+            _logger.LogEntitiesFetched(nameof(Devis), pagedQuotations.Items.Count);
 
             return pagedQuotations;
         }

--- a/src/TunNetCom.SilkRoadErp.Sales.Contracts/Invoice/GetInvoiceListWithSummary.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Contracts/Invoice/GetInvoiceListWithSummary.cs
@@ -12,5 +12,5 @@ public class GetInvoiceListWithSummary
     public decimal TotalNetAmount { get; set; }
 
     [JsonPropertyName("invoices")]
-    public List<InvoiceResponse> Invoices { get; set; } = new List<InvoiceResponse>();
+    public PagedList<InvoiceResponse> Invoices { get; set; } = new PagedList<InvoiceResponse>();
 }

--- a/src/TunNetCom.SilkRoadErp.Sales.Contracts/PagedList.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Contracts/PagedList.cs
@@ -2,12 +2,18 @@
 
 namespace TunNetCom.SilkRoadErp.Sales.Contracts;
 
-public class PagedList<T> : List<T>
+public class PagedList<T>
 {
     public int CurrentPage { get; set; }
     public int TotalPages { get; set; }
     public int PageSize { get; set; }
+
+    public List<T> Items { get; set; }
+
+
+    [JsonPropertyName("totalCount")]
     public int TotalCount { get; set; }
+
     public bool HasPrevious => CurrentPage > 1;
     public bool HasNext => CurrentPage < TotalPages;
 
@@ -19,7 +25,7 @@ public class PagedList<T> : List<T>
         PageSize = pageSize;
         CurrentPage = pageNumber;
         TotalPages = (int)Math.Ceiling(count / (double)pageSize);
-        AddRange(items);
+        Items = items;
     }
 
     public static async Task<PagedList<T>> ToPagedListAsync(

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.HttpClients/Services/DeliveryNote/IDeliveryNoteApiClient.cs
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.HttpClients/Services/DeliveryNote/IDeliveryNoteApiClient.cs
@@ -1,5 +1,4 @@
-﻿using TunNetCom.SilkRoadErp.Sales.Contracts.Customers;
-using TunNetCom.SilkRoadErp.Sales.Contracts.DeliveryNote.Requests;
+﻿using TunNetCom.SilkRoadErp.Sales.Contracts.DeliveryNote.Requests;
 using TunNetCom.SilkRoadErp.Sales.Contracts.DeliveryNote.Responses;
 
 namespace TunNetCom.SilkRoadErp.Sales.HttpClients.Services.DeliveryNote;
@@ -21,15 +20,18 @@ public interface IDeliveryNoteApiClient
     Task<List<DeliveryNoteResponse>> GetDeliveryNotesByInvoiceId(
         int invoiceId);
 
-    Task<bool> AttachToInvoiceAsync(AttachToInvoiceRequest request, CancellationToken cancellationToken);
+    Task<bool> AttachToInvoiceAsync(
+        AttachToInvoiceRequest request,
+        CancellationToken cancellationToken);
 
     Task<List<DeliveryNoteResponse>> GetUninvoicedDeliveryNotesAsync(
         int clientId,
         CancellationToken cancellationToken);
 
     Task<OneOf<bool, BadRequestResponse>> DetachFromInvoiceAsync(
-DetachFromInvoiceRequest request,
-CancellationToken cancellationToken);
+        DetachFromInvoiceRequest request,
+        CancellationToken cancellationToken);
+
     Task<GetDeliveryNotesWithSummariesResponse> GetDeliveryNotesWithSummariesAsync(
        int customerId,
        int? invoiceId,

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Customers/CustomersList.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Customers/CustomersList.razor
@@ -108,7 +108,7 @@
             };
 
         var result = await customerService.GetAsync(customersParameters, cancellationTokenSource.Token);
-        return await Task.FromResult(new GridDataProviderResult<CustomerResponse> { Data = result, TotalCount = result.TotalCount });
+        return await Task.FromResult(new GridDataProviderResult<CustomerResponse> { Data = result.Items, TotalCount = result.TotalCount });
     }
 
     public void Dispose()

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/DeliveryNote/ManageDeliveryNotes.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/DeliveryNote/ManageDeliveryNotes.razor
@@ -118,11 +118,11 @@
     {
         if (!string.IsNullOrEmpty(CustomerSearchKeyword))
         {
-            FilteredCustomers = await CustomersApiClient.SearchCustomers(new QueryStringParameters
+            FilteredCustomers = (await CustomersApiClient.SearchCustomers(new QueryStringParameters
                 {
                     SearchKeyword = CustomerSearchKeyword,
                   
-                }, CancellationToken.None);
+            }, CancellationToken.None)).Items;
             StateHasChanged();
         }
     }
@@ -143,14 +143,14 @@
         else
         {
             // Appel à l'API pour récupérer les bons de livraison avec des filtres standards
-            DeliveryNotes = await DeliveryNoteService.GetDeliveryNotes(
+            DeliveryNotes = (await DeliveryNoteService.GetDeliveryNotes(
                 pageNumber: 1,
                 pageSize: 1000,
                 customerId: null,
                 searchKeyword: string.Empty,
                 isFactured: true
               
-            );
+            )).Items;
         }
 
         if (DeliveryNotes != null && DeliveryNotes.Any())

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/DeliveryNote/ManageInvoices.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/DeliveryNote/ManageInvoices.razor
@@ -25,14 +25,11 @@
 @inject NotificationService NotificationService
 
 <div>
-
     <h3>@Localizer["manage_invoices"]</h3>
 
     <RadzenStack Orientation="Radzen.Orientation.Horizontal"
     AlignItems="AlignItems.Center"
-    JustifyContent="JustifyContent.Center"
-    Gap="0.5rem"
-    Class="rz-p-12">
+    JustifyContent="JustifyContent.Left">
         <RadzenLabel Text="@Localizer["select_customer"]" Component="DropDownDataGridFilteringLoadData" />
         <RadzenDropDownDataGrid AllowClear="true"
         @bind-Value="@SelectedCustomerId"
@@ -62,11 +59,14 @@
                 @ref="InvoiceGrid"
                 AllowFiltering="true"
                 AllowPaging="true"
-                PageSize="5"
+                Page="@OnPage"
+                PageSize="_defaultPageSize"
                 PagerHorizontalAlign="HorizontalAlign.Left"
                 ShowPagingSummary="true"
                 AllowSorting="true"
-                Data="@getInvoiceListWithSummary.Invoices"
+                Count="@getInvoiceListWithSummary.Invoices.TotalCount"
+                Data="@getInvoiceListWithSummary.Invoices.Items"
+                                LoadData="@LoadInvoiceData"
                 @bind-Value="@SelectedInvoice"
                 SelectionMode="DataGridSelectionMode.Single">
                     <HeaderTemplate>
@@ -112,13 +112,13 @@
                                         FilterPopupRenderMode="PopupRenderMode.OnDemand"
                                         FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
                                         AllowPaging="true"
-                                        PageSize="4"
+                                        PageSize="_defaultPageSize"
                                         PagerHorizontalAlign="HorizontalAlign.Left"
                                         ShowPagingSummary="true"
                                         AllowSorting="true"
-                                        Sort="@OnSort"
+                                        GotoFirstPageOnSort="true"
                                         TItem="GetDeliveryNoteBaseInfos"
-                                        Data="@_getDeliveryNotesWithSummariesResponse.GetDeliveryNoteBaseInfos"
+                                        Data="@_getDeliveryNotesWithSummariesResponse.GetDeliveryNoteBaseInfos.Items"
                                         ColumnWidth="200px"
                                         SelectionMode="DataGridSelectionMode.Multiple"
                                         @bind-Value="@SelectedDeliveryNotesToDetach">
@@ -169,9 +169,9 @@
                 AllowPaging="true"
                 PagerHorizontalAlign="HorizontalAlign.Left"
                 ShowPagingSummary="true"
-                PageSize="4"
+                PageSize="_defaultPageSize"
                 AllowSorting="true"
-                Data="@UninvoicedDeliveryNotesSummary.GetDeliveryNoteBaseInfos"
+                Data="@UninvoicedDeliveryNotesSummary.GetDeliveryNoteBaseInfos.Items"
                 ColumnWidth="200px"
                 SelectionMode="DataGridSelectionMode.Multiple"
                 @bind-Value="@SelectedDeliveryNotesToAttach">
@@ -216,6 +216,7 @@
 
 @code {
     #region Fields and Properties
+    private const int _defaultPageSize = 5;
     private int _selectedCustomerId;
     private int SelectedCustomerId
     {
@@ -309,7 +310,7 @@
         try
         {
             var pagedCustomers = await customerService.GetAsync(parameters, _cancellationTokenSource.Token);
-            FilteredCustomers = pagedCustomers;
+            FilteredCustomers = pagedCustomers.Items;
         }
 
         catch (Exception ex)
@@ -330,11 +331,11 @@
         var parameters = new QueryStringParameters
             {
                 PageNumber = 1,
-                PageSize = 10,
+                PageSize = _defaultPageSize,
                 SearchKeyword = null
             };
 
-        FilteredCustomers = await customerService.GetAsync(parameters, _cancellationTokenSource.Token);
+        FilteredCustomers = (await customerService.GetAsync(parameters, _cancellationTokenSource.Token)).Items;
         await InvokeAsync(StateHasChanged);
     }
 
@@ -348,7 +349,7 @@
                 sortOrder: null,
                 sortProperty: null,
                 pageNumber: 1,
-                pageSize: 50,
+                pageSize: _defaultPageSize,
                 cancellationToken: _cancellationTokenSource.Token
             );
         await InvokeAsync(StateHasChanged);
@@ -359,7 +360,7 @@
             {
             //TODO remove magic numbers
                 PageNumber = 1,
-                PageSize = 20,
+                PageSize = _defaultPageSize,
                 SearchKeyword = null
             };
 
@@ -398,9 +399,9 @@
                 invoiceId: null,
                 isInvoiced: false,
                 sortOrder: null,
-				sortProperty: null,
+                sortProperty: null,
                 pageNumber: 1,
-                pageSize: 50,
+                pageSize: _defaultPageSize,
                 cancellationToken: _cancellationTokenSource.Token
             );
         }
@@ -418,12 +419,11 @@
         await InvokeAsync(StateHasChanged);
     }
 
-    void OnSort(DataGridColumnSortEventArgs<GetDeliveryNoteBaseInfos> args)
-      {
-
+    async Task OnSort(DataGridColumnSortEventArgs<GetDeliveryNoteBaseInfos> args)
+    {
         var columnName = args.Column.Property;
-		var sortOrder = args.SortOrder;
-        FetchSortedDeliveryNotesAsync(columnName, sortOrder.ToString());
+        var sortOrder = args.SortOrder;
+        await FetchSortedDeliveryNotesAsync(columnName, sortOrder.ToString());
     }
 
     private async Task FetchSortedDeliveryNotesAsync(string columnName, string sortOrder)
@@ -433,7 +433,7 @@
             invoiceId: SelectedInvoiceId,
             isInvoiced: true,
             pageNumber: 1,
-            pageSize: 50,
+            pageSize: _defaultPageSize,
             sortOrder: sortOrder,
             sortProperty: columnName,
             cancellationToken: _cancellationTokenSource.Token
@@ -521,6 +521,17 @@
                 });
             Console.WriteLine($"Error detaching delivery notes from invoice: {ex.Message}");
         }
+    }
+
+    void OnPage(PagerEventArgs args)
+    {
+        //
+    }
+
+    private async Task LoadInvoiceData(LoadDataArgs args)
+    {
+        // 
+        await Task.CompletedTask;
     }
 
     #endregion

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Products/ProductsList.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Products/ProductsList.razor
@@ -120,7 +120,7 @@
             };
 
         var result = await productService.GetPagedAsync(productsParameters, cancellationTokenSource.Token);
-        return await Task.FromResult(new GridDataProviderResult<ProductResponse> { Data = result, TotalCount = result.TotalCount });
+        return await Task.FromResult(new GridDataProviderResult<ProductResponse> { Data = result.Items, TotalCount = result.TotalCount });
     }
 
     public void Dispose()

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/ProvidersList.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/ProvidersList.razor
@@ -111,7 +111,7 @@
             };
 
         var result = await providerService.GetPagedAsync(providersParameters, cancellationTokenSource.Token);
-        return await Task.FromResult(new GridDataProviderResult<ProviderResponse> { Data = result, TotalCount = result.TotalCount });
+        return await Task.FromResult(new GridDataProviderResult<ProviderResponse> { Data = result.Items, TotalCount = result.TotalCount });
     }
 
     public void Dispose()


### PR DESCRIPTION
Update pagination handling and logging for delivery notes #97 

- Changed logging to use `Items.Count` for paged results.
- Added new classes and methods for handling delivery notes by invoice ID.
- Refactored `PagedList<T>` to include pagination properties and replace `List<T>`.
- Updated `GetInvoiceListWithSummary` to use `PagedList<InvoiceResponse>`.
- Modified Razor components to accommodate new paged result structures.
- Improved code readability and maintainability with refactoring and async/await patterns.

