### PR TITLE
Refactor validation and UI components with Radzen #154

### DIFF
--- a/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Providers/UpdateProvider/UpdateProviderValidator.cs
+++ b/src/TunNetCom.SilkRoadErp.Sales.Api/Features/Providers/UpdateProvider/UpdateProviderValidator.cs
@@ -35,9 +35,6 @@ public class UpdateProviderValidator : AbstractValidator<UpdateProviderCommand>
            .MaximumLength(50).WithMessage("mail_must_be_less_than_50_characters")
            .EmailAddress().WithMessage("mail_must_be_a_valid_email_address");
 
-        RuleFor(x => x.Constructeur)
-           .NotEmpty().WithMessage("constructor_must_be_a_valid_boolean_value_true_or_false");
-
         RuleFor(x => x.Adresse)
             .MaximumLength(50).WithMessage("adress_must_be_less_than_50_characters");
     }

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/ManageProvidersInvoices.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/ManageProvidersInvoices.razor
@@ -122,6 +122,9 @@
                                 @bind-Value="@_selectedReceiptNotesToDetach"
                                 Style="border: none;"
                                 Class="custom-grid">
+                    <EmptyTemplate>
+                        <p style="color: lightgrey; font-size: 24px; text-align: center; margin: 2rem;">No records to display.</p>
+                    </EmptyTemplate>
                     <HeaderTemplate>
                         <div style="font-size: 1.25rem; font-weight: 600; color: #1a1a1a; padding-bottom: 1rem;">
                             @Localizer["receipt_notes_details"]
@@ -177,6 +180,9 @@
                                 SelectionMode="DataGridSelectionMode.Single"
                                 Style="border: none;"
                                 Class="custom-grid">
+                    <EmptyTemplate>
+                        <p style="color: lightgrey; font-size: 24px; text-align: center; margin: 2rem;">No records to display.</p>
+                    </EmptyTemplate>
                     <HeaderTemplate>
                         <div style="font-size: 1.25rem; font-weight: 600; color: #1a1a1a; padding-bottom: 1rem;">
                             @Localizer["provider_invoice_details"]
@@ -255,6 +261,9 @@
                                 @bind-Value="@_selectedReceiptNotesToAttach"
                                 Style="border: none;"
                                 Class="custom-grid">
+                    <EmptyTemplate>
+                        <p style="color: lightgrey; font-size: 24px; text-align: center; margin: 2rem;">No records to display.</p>
+                    </EmptyTemplate>
                     <HeaderTemplate>
                         <div style="font-size: 1.25rem; font-weight: 600; color: #1a1a1a; padding-bottom: 1rem;">
                             @Localizer["uninvoiced_receipt_notes_details"]

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/PreviewDialog.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/PreviewDialog.razor
@@ -1,0 +1,81 @@
+﻿@page "/dialogcard/{ProviderId}"
+
+@using Radzen
+@using Radzen.Blazor
+@using Microsoft.EntityFrameworkCore
+@using TunNetCom.SilkRoadErp.Sales.HttpClients.Services.Providers
+@inject IProvidersApiClient providerService
+@inject Radzen.DialogService dialogService
+
+<RadzenStack Gap="1rem" Orientation="Radzen.Orientation.Vertical" JustifyContent="JustifyContent.SpaceBetween" Style="height: 100%;">
+    <RadzenStack>
+        <RadzenRow>
+            <RadzenColumn Size="12" SizeMD="6" class="rz-p-4 rz-border-radius-1" Style="border: var(--rz-grid-cell-border)">
+                <RadzenText TextStyle="TextStyle.Subtitle1">Informations du Fournisseur</RadzenText>
+                <RadzenStack Gap="0" class="rz-text-truncate">
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Nom</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@provider?.Nom</b></RadzenText>
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Téléphone</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@provider?.Tel</b></RadzenText>
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Email</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@provider?.Mail</b></RadzenText>
+                    @if (!string.IsNullOrEmpty(provider?.MailDeux))
+                    {
+                        <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Email Secondaire</RadzenText>
+                        <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@provider?.MailDeux</b></RadzenText>
+                    }
+                </RadzenStack>
+            </RadzenColumn>
+            <RadzenColumn Size="12" SizeMD="6" class="rz-p-4 rz-border-radius-1" Style="border: var(--rz-grid-cell-border)">
+                <RadzenText TextStyle="TextStyle.Subtitle1">Détails Supplémentaires</RadzenText>
+                <RadzenStack Gap="0" class="rz-text-truncate">
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Adresse</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@provider?.Adresse</b></RadzenText>
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Fax</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@(provider?.Fax ?? "N/A")</b></RadzenText>
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Matricule</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@(provider?.Matricule ?? "N/A")</b></RadzenText>
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-mt-2 rz-my-0" Style="color: var(--rz-text-tertiary-color);">Constructeur</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@(provider?.Constructeur == true ? "Oui" : "Non")</b></RadzenText>
+                </RadzenStack>
+            </RadzenColumn>
+        </RadzenRow>
+        <RadzenStack Orientation="Radzen.Orientation.Horizontal" JustifyContent="JustifyContent.SpaceBetween" AlignItems="AlignItems.Center">
+            <RadzenText TextStyle="TextStyle.Subtitle1" class="rz-m-0"><b>Immatriculation Fiscale</b></RadzenText>
+            <RadzenBadge BadgeStyle="BadgeStyle.Secondary" Text="@(provider?.Code ?? "N/A")" />
+        </RadzenStack>
+        <RadzenCard class="rz-p-4 rz-border-radius-1" Style="border: var(--rz-grid-cell-border)">
+            <RadzenText TextStyle="TextStyle.Subtitle1">Codes du Fournisseur</RadzenText>
+            <RadzenStack Orientation="Radzen.Orientation.Horizontal" Gap="2rem" class="rz-text-truncate" Wrap="FlexWrap.Wrap">
+                <RadzenStack Gap="0">
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-my-0" Style="color: var(--rz-text-tertiary-color);">Code</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@(provider?.Code ?? "N/A")</b></RadzenText>
+                </RadzenStack>
+                <RadzenStack Gap="0">
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-my-0" Style="color: var(--rz-text-tertiary-color);">Code Catégorie</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@(provider?.CodeCat ?? "N/A")</b></RadzenText>
+                </RadzenStack>
+                <RadzenStack Gap="0">
+                    <RadzenText TextStyle="TextStyle.Overline" class="rz-my-0" Style="color: var(--rz-text-tertiary-color);">Établissement Secondaire</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Body1" class="rz-text-truncate"><b>@(provider?.EtbSec ?? "N/A")</b></RadzenText>
+                </RadzenStack>
+            </RadzenStack>
+        </RadzenCard>
+    </RadzenStack>
+    <RadzenStack Visible="@ShowClose" Orientation="Radzen.Orientation.Horizontal" JustifyContent="JustifyContent.End" Gap="0.5rem">
+        <RadzenButton Click="@((args) => dialogService.Close(true))" Variant="Variant.Flat" Text="Fermer" Style="width: 120px" />
+    </RadzenStack>
+</RadzenStack>
+
+@code {
+    [Parameter] public int ProviderId { get; set; }
+    [Parameter] public bool ShowClose { get; set; } = true;
+
+    ProviderResponse provider;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var result = await providerService.GetAsync(ProviderId, default);
+        provider = result.AsT0;
+    }
+}

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/ProvidersList.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/ProvidersList.razor
@@ -4,120 +4,390 @@
 @using TunNetCom.SilkRoadErp.Sales.WebApp.Locales
 @using TunNetCom.SilkRoadErp.Sales.HttpClients.Services
 @using TunNetCom.SilkRoadErp.Sales.Contracts.Providers
-@using BlazorBootstrap
+@using Radzen
+@using Radzen.Blazor
 @using TunNetCom.NotFoundModal
 @using TunNetCom.DeleteModal
+@using Microsoft.JSInterop
+@using System.Text.Json
+
+@inject DialogService DialogService
+@inject IJSRuntime JSRuntime
 @inject IProvidersApiClient providerService
 @inject NavigationManager navigationManager
 @inject IStringLocalizer<SharedResource> Localizer
+@inject DialogService DialogService
+@inject NotificationService NotificationService
 
-<div class="container mt-4">
-    <div class="container mt-4">
-        <div class="row">
-            <div class="col-md-6 d-flex align-items-center">
-                <h3 class="mb-3">@Localizer["providers"]</h3>
-            </div>
-            <div class="col-md-6 d-flex justify-content-end align-items-center">
-                <button class="btn btn-primary mb-3" @onclick="CreateProvider">@Localizer["add_provider"]</button>
-            </div>
+<div class="providers-container">
+    <div class="providers-card">
+        <div class="providers-header">
+            <h3 class="providers-title">@Localizer["providers"]</h3>
+            <RadzenButton Icon="add" Text="@Localizer["add_provider"]"
+                          ButtonStyle="ButtonStyle.Primary"
+                          Click="CreateProvider"
+                          Class="btn-primary" />
         </div>
+
+        <RadzenTextBox Placeholder="@Localizer["Search"]"
+                       Change="@(async (string value) => await LoadData(new LoadDataArgs() { Filter = value }))"
+                       Class="providers-search" />
+
+        <RadzenDataGrid TItem="ProviderResponse"
+                        GridLines="@GridLines"
+                        Data="@providers"
+                        Count="@totalCount"
+                        LoadData="@LoadData"
+                        AllowFiltering="true"
+                        AllowPaging="true"
+                        AllowSorting="true"
+                        FilterPopupRenderMode="PopupRenderMode.OnDemand"
+                        FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                        PageSize="@PageSize"
+                        Density="Density.Compact"
+                        Class="providers-grid"
+                        @ref="grid">
+            <EmptyTemplate>
+                <p style="color: lightgrey; font-size: 24px; text-align: center; margin: 2rem;">No records to display.</p>
+            </EmptyTemplate>
+            <Columns>
+                <RadzenDataGridColumn TItem="ProviderResponse" Property="Nom" Title="@Localizer["provider_name"]" Width="@NameColumnWidth">
+                    <Template Context="provider">
+                        <span class="grid-cell">@provider.Nom</span>
+                    </Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn TItem="ProviderResponse" Property="Tel" Title="@Localizer["provider_phone"]" Width="@PhoneColumnWidth">
+                    <Template Context="provider">
+                        <span class="grid-cell">@provider.Tel</span>
+                    </Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn TItem="ProviderResponse" Property="Mail" Title="@Localizer["provider_email"]" Width="@EmailColumnWidth">
+                    <Template Context="provider">
+                        <span class="grid-cell">@provider.Mail</span>
+                    </Template>
+                </RadzenDataGridColumn>
+                <RadzenDataGridColumn TItem="ProviderResponse" Filterable="false" Sortable="false" Width="@ActionsColumnWidth" TextAlign="TextAlign.Center">
+                    <Template Context="provider">
+                        <RadzenButton Icon="account_circle" ButtonStyle="ButtonStyle.Info" Variant="Variant.Outlined" Size="ButtonSize.Medium" Shade="Shade.Lighter"
+                                      Click="@(() => OpenOrder(provider.Id))"
+                                      Title="@Localizer["delete_button_label"]" />
+                        <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Success" Variant="Variant.Outlined" Size="ButtonSize.Medium" Shade="Shade.Lighter"  class="rz-my-1 rz-ms-1"
+                                          Click="@(() => EditProvider(provider.Id))"
+                                          Title="@Localizer["edit_button_label"]" />
+                        <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger" Variant="Variant.Outlined" Size="ButtonSize.Medium" Shade="Shade.Lighter"
+                                          Click="@(() => OnClickDeleteButton(provider.Id))"
+                                          Title="@Localizer["delete_button_label"]" />
+                    </Template>
+                </RadzenDataGridColumn>
+            </Columns>
+        </RadzenDataGrid>
     </div>
-    <input class="form-control mb-3" placeholder="@Localizer["Search"]" @bind="searchKeyword" @oninput="SearchClients" />
-
-
-    <Grid TItem="ProviderResponse"
-          Class="table table-hover table-bordered table-striped"
-          DataProvider="ProvidersDataProvider"
-          AllowPaging="true"
-          AllowSorting="true"
-          Responsive="true"
-          @ref="grid">
-        <GridColumn TItem="ProviderResponse" HeaderText="@Localizer["provider_name"]" PropertyName="ProviderName" SortString="ProviderName" SortKeySelector="item => item.Nom" FilterTextboxWidth="80">
-            @context.Nom
-        </GridColumn>
-        <GridColumn TItem="ProviderResponse" HeaderText="@Localizer["provider_phone"]" PropertyName="ProviderPhone" SortString="ProviderPhone" SortKeySelector="item => item.Tel" FilterTextboxWidth="100">
-            @context.Tel
-        </GridColumn>
-        <GridColumn TItem="ProviderResponse" HeaderText="@Localizer["provider_email"]" PropertyName="ProviderEmail" SortString="ProviderEmail" SortKeySelector="item => item.Mail" FilterTextboxWidth="120">
-            @context.Mail
-        </GridColumn>
-        <GridColumn TItem="ProviderResponse" HeaderText="@Localizer["actions_label"]">
-            <Button Color="ButtonColor.Primary" @onclick="((args) => OnClickEditButton(args, context.Id))">
-                @Localizer["edit_button_label"]
-            </Button>
-            <Button Color="ButtonColor.Danger" @onclick="((args) => OnClickDeleteButton(args, context.Id))">
-                @Localizer["delete_button_label"]
-            </Button>
-        </GridColumn>
-    </Grid>
 </div>
 
-<Modal @ref="yesOrNoDeleteModal" />
-<Modal @ref="notFoundModal" />
-
-@code {
-    [Inject] protected ToastService toastService { get; set; } = default!;
-    private string searchKeyword = string.Empty;
-    int currentProviderIdToDelete;
-    private CancellationTokenSource cancellationTokenSource = new();
-    private Modal yesOrNoDeleteModal = default!;
-    Grid<ProviderResponse> grid = default!;
-    private Modal notFoundModal = default!;
-
-
-    private async Task ProcessDelete(MouseEventArgs e)
-    {
-        await providerService.DeleteAsync(currentProviderIdToDelete, cancellationTokenSource.Token);
-        toastService.Notify(new(ToastType.Warning, $"{Localizer["provider"]} {Localizer["deleted_with_success"]}"));
-        await yesOrNoDeleteModal.HideAsync();
+<style>
+    :root {
+        --primary-color: #1a73e8;
+        --primary-hover: #135ab6;
+        --danger-color: #d32f2f;
+        --danger-hover: #b71c1c;
+        --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        --info-color: #0288d1;
+        --info-hover: #01579b;
+        --card-bg: #ffffff;
+        --grid-header-bg: #f5f7fa;
+        --grid-header-color: #202124;
+        --grid-row-hover: #f1f3f5;
+        --border-radius: 8px;
+        --border-color: #e0e0e0;
+        --text-color: #202124;
+        --muted-text: #5f6368;
     }
 
-    protected void OnClickEditButton(EventArgs args, int id)
-    {
-        EditProvider(id);
+    .providers-container {
+        padding: 1.25rem;
+        max-width: 1280px;
+        margin: 1rem auto;
+        font-family: font-family: Georgia, serif;
     }
 
-    private async Task SearchClients(ChangeEventArgs e)
-    {
-        searchKeyword = e?.Value?.ToString() ?? string.Empty;
-
-        await grid.RefreshDataAsync();
+    .providers-card {
+        background: var(--card-bg);
+        border-radius: var(--border-radius);
+        box-shadow: var(--card-shadow);
+        padding: 1.5rem;
+        border: none;
     }
 
-    protected async Task OnClickDeleteButton(EventArgs args, int id)
-    {
-        currentProviderIdToDelete = id;
-        var parameters = new Dictionary<string, object>();
-        parameters.Add("OnclickCallback", EventCallback.Factory.Create<MouseEventArgs>(this, ProcessDelete));
-        await yesOrNoDeleteModal.ShowAsync<DeleteModal>(title: Localizer["delete_modal_title"], parameters: parameters);
+    .providers-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.25rem;
     }
 
-    private async Task<GridDataProviderResult<ProviderResponse>> ProvidersDataProvider(
-        GridDataProviderRequest<ProviderResponse> request)
-    {
-        string sortString = string.Empty;
-        SortDirection sortDirection = SortDirection.None;
+    .providers-title {
+        color: var(--text-color);
+        font-weight: 600;
+        margin: 0;
+        font-size: 2rem;
+        line-height: 1.2;
+    }
 
-        if (request.Sorting is not null && request.Sorting.Any())
-        {
-            sortString = request.Sorting.FirstOrDefault()!.SortString;
-            sortDirection = request.Sorting.FirstOrDefault()!.SortDirection;
+    .providers-search {
+        width: 100%;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border-color);
+        padding: 0.75rem 1rem;
+        margin-bottom: 1.25rem;
+        font-size: 0.95rem;
+        color: var(--text-color);
+        background: #fafafa;
+    }
+
+        .providers-search:focus {
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.1);
+            outline: none;
+            background: #ffffff;
         }
-        var providersParameters = new QueryStringParameters
-            {
-                PageNumber = request.PageNumber,
-                PageSize = request.PageSize,
-                SearchKeyword = searchKeyword
-            };
 
-        var result = await providerService.GetPagedAsync(providersParameters, cancellationTokenSource.Token);
-        return await Task.FromResult(new GridDataProviderResult<ProviderResponse> { Data = result.Items, TotalCount = result.TotalCount });
+    .providers-grid {
+        border-radius: var(--border-radius);
+        overflow: hidden;
+        background: var(--card-bg);
+        border: none;
+    }
+
+        .providers-grid .rz-datatable thead {
+            background: var(--grid-header-bg);
+            color: var(--grid-header-color);
+            border-bottom: 1px solid var(--border-color);
+        }
+
+            .providers-grid .rz-datatable thead th {
+                font-weight: 500;
+                padding: 0.75rem 1rem;
+                text-align: left;
+                font-size: 0.9rem;
+                text-transform: uppercase;
+                letter-spacing: 0.02em;
+            }
+
+        .providers-grid .rz-datatable tbody tr {
+            border-bottom: 1px solid var(--border-color);
+        }
+
+            .providers-grid .rz-datatable tbody tr:last-child {
+                border-bottom: none;
+            }
+
+            .providers-grid .rz-datatable tbody tr:hover {
+                background: var(--grid-row-hover);
+            }
+
+    .grid-cell {
+        padding: 0.75rem 1rem;
+        font-size: 0.95rem;
+        color: var(--text-color);
+        line-height: 1.5;
+    }
+
+    .providers-grid .rz-grid-table {
+        border-collapse: collapse;
+    }
+
+</style>
+@code {
+    private const int PageSize = 10;
+    private const string NameColumnWidth = "200px";
+    private const string PhoneColumnWidth = "150px";
+    private const string EmailColumnWidth = "200px";
+    private const string ActionsColumnWidth = "150px";
+    private const int NotificationDuration = 4000;
+    private const int InitialPageNumber = 1;
+    private const int InitialPageSize = 10;
+    Radzen.DataGridGridLines GridLines = Radzen.DataGridGridLines.Default;
+
+    [Inject] protected ToastService toastService { get; set; } = default!;
+
+    private string searchKeyword = string.Empty;
+    private int currentProviderIdToDelete;
+    private CancellationTokenSource cancellationTokenSource = new();
+    private RadzenDataGrid<ProviderResponse> grid = default!;
+    private IEnumerable<ProviderResponse> providers = new List<ProviderResponse>();
+    private int totalCount;
+
+    #region Lifecycle Methods
+    protected override async Task OnInitializedAsync()
+    {
+        await SearchProviders(null);
     }
 
     public void Dispose()
     {
         cancellationTokenSource.Cancel();
         cancellationTokenSource.Dispose();
+    }
+    #endregion
+
+    private async Task LoadData(LoadDataArgs args)
+    {
+        var queryParameters = new QueryStringParameters
+            {
+                PageNumber = (args.Skip ?? 0) / (args.Top ?? PageSize) + 1,
+                PageSize = args.Top ?? PageSize,
+                SearchKeyword = args.Filter
+            };
+
+        var result = await providerService.GetPagedAsync(queryParameters, cancellationTokenSource.Token);
+        providers = result.Items;
+        totalCount = result.TotalCount;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task SearchProviders(string value)
+    {
+        searchKeyword = value;
+        var queryParameters = new QueryStringParameters
+            {
+                PageNumber = InitialPageNumber,
+                PageSize = InitialPageSize,
+                SearchKeyword = value
+            };
+
+        var result = await providerService.GetPagedAsync(queryParameters, cancellationTokenSource.Token);
+        providers = result.Items;
+        totalCount = result.TotalCount;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnClickDeleteButton(int id)
+    {
+        currentProviderIdToDelete = id;
+        var confirmed = await DialogService.Confirm(
+            Localizer["delete_modal_title"],
+            Localizer["delete_modal_message"],
+            new ConfirmOptions
+                {
+                    OkButtonText = Localizer["yes"],
+                    CancelButtonText = Localizer["no"]
+                });
+
+        if (confirmed == true)
+        {
+            await providerService.DeleteAsync(currentProviderIdToDelete, cancellationTokenSource.Token);
+            ShowNotification(
+                NotificationSeverity.Warning,
+                Localizer["provider"],
+                Localizer["deleted_with_success"]);
+
+            await grid.Reload();
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public async Task OpenOrder(int providerId)
+    {
+        await LoadStateAsync();
+
+        await DialogService.OpenAsync<PreviewDialog>($"ProviderId {providerId}",
+               new Dictionary<string, object>() { { "ProviderId", providerId } },
+               new DialogOptions()
+                   {
+                       Resizable = true,
+                       Draggable = true,
+                       Resize = OnResize,
+                       Drag = OnDrag,
+                       Width = Settings != null ? Settings.Width : "700px",
+                       Height = Settings != null ? Settings.Height : "512px",
+                       Left = Settings != null ? Settings.Left : null,
+                       Top = Settings != null ? Settings.Top : null
+                   });
+
+        await SaveStateAsync();
+    }
+    void OnDrag(System.Drawing.Point point)
+    {
+        JSRuntime.InvokeVoidAsync("eval", $"console.log('Dialog drag. Left:{point.X}, Top:{point.Y}')");
+
+        if (Settings == null)
+        {
+            Settings = new DialogSettings();
+        }
+
+        Settings.Left = $"{point.X}px";
+        Settings.Top = $"{point.Y}px";
+
+        InvokeAsync(SaveStateAsync);
+    }
+
+    void OnResize(System.Drawing.Size size)
+    {
+        JSRuntime.InvokeVoidAsync("eval", $"console.log('Dialog resize. Width:{size.Width}, Height:{size.Height}')");
+
+        if (Settings == null)
+        {
+            Settings = new DialogSettings();
+        }
+
+        Settings.Width = $"{size.Width}px";
+        Settings.Height = $"{size.Height}px";
+
+        InvokeAsync(SaveStateAsync);
+    }
+
+    DialogSettings _settings;
+    public DialogSettings Settings
+    {
+        get
+        {
+            return _settings;
+        }
+        set
+        {
+            if (_settings != value)
+            {
+                _settings = value;
+                InvokeAsync(SaveStateAsync);
+            }
+        }
+    }
+
+    private async Task LoadStateAsync()
+    {
+        await Task.CompletedTask;
+
+        var result = await JSRuntime.InvokeAsync<string>("window.localStorage.getItem", "DialogSettings");
+        if (!string.IsNullOrEmpty(result))
+        {
+            _settings = JsonSerializer.Deserialize<DialogSettings>(result);
+        }
+    }
+
+    private async Task SaveStateAsync()
+    {
+        await Task.CompletedTask;
+
+        await JSRuntime.InvokeVoidAsync("window.localStorage.setItem", "DialogSettings", JsonSerializer.Serialize<DialogSettings>(Settings));
+    }
+
+    public class DialogSettings
+    {
+        public string Left { get; set; }
+        public string Top { get; set; }
+        public string Width { get; set; }
+        public string Height { get; set; }
+    }
+
+    private void ShowNotification(NotificationSeverity severity, string summary, string detail)
+    {
+        NotificationService.Notify(new NotificationMessage
+            {
+                Severity = severity,
+                Summary = summary,
+                Detail = detail,
+                Duration = NotificationDuration
+            });
     }
 
     private void CreateProvider()


### PR DESCRIPTION
- Updated `UpdateProviderValidator` to remove validation for `Constructeur` while retaining rules for `MailDeux` and `Adresse`.
- Added `EmptyTemplate` to data grids in `ManageProvidersInvoices.razor` for better user feedback when no records are available.
- Revamped `ProvidersList.razor` to utilize `RadzenDataGrid`, enhancing functionality with filtering, paging, and sorting features.
- Introduced a new `PreviewDialog.razor` component for displaying detailed provider information using `Radzen` components.
- Updated `_Imports.razor` for improved component usage.
- Overall, these changes modernize the UI and improve validation logic.