### PR TITLE
Refactor provider UI and update translations

### DIFF
--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/EditProvider.razor
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Components/Pages/Providers/EditProvider.razor
@@ -80,17 +80,10 @@
                      Gap="1rem"
                      Class="mb-4">
             <RadzenLabel Text="@localizer["provider_constructor"]" />
-            <RadzenToggleButton @bind-Value="provider.Constructeur"
-                                TValue="bool"
-                                Text="@(provider.Constructeur ? localizer["True"] : localizer["False"])"
-                                Icon="@(provider.Constructeur ? "check_circle" : "cancel")"
-                                ButtonStyle="ButtonStyle.Danger"
-                                ToggleButtonStyle="ButtonStyle.Success"
-                                Style="min-width: 150px;"
-                                InputAttributes="@(new Dictionary<string, object> { { "aria-label", localizer["provider_constructor"] } })" />
+            <RadzenSwitch @bind-Value="provider.Constructeur" TValue="bool" />
         </RadzenStack>
 
-        <RadzenRow>
+        <RadzenRow Style="margin-top: 20px;">
             <RadzenColumn Width="12" Style="text-align: right;">
                 <RadzenButton ButtonType="Radzen.ButtonType.Submit"
                               Text="@localizer["save_label"]"

--- a/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Locales/SharedResource.en.resx
+++ b/src/WebApps/TunNetCom.SilkRoadErp.Sales.WebApp/Locales/SharedResource.en.resx
@@ -288,4 +288,40 @@
   <data name="vat_percentage" xml:space="preserve">
     <value />
   </data>
+  <data name="provider_adress" xml:space="preserve">
+    <value>Address</value>
+  </data>
+  <data name="provider_code" xml:space="preserve">
+    <value>Code</value>
+  </data>
+  <data name="provider_code_cat" xml:space="preserve">
+    <value>CodeCat</value>
+  </data>
+  <data name="provider_constructor" xml:space="preserve">
+    <value>Constructor</value>
+  </data>
+  <data name="provider_email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="provider_etb_sec" xml:space="preserve">
+    <value>Secondary Establishment</value>
+  </data>
+  <data name="provider_fax" xml:space="preserve">
+    <value>Fax</value>
+  </data>
+  <data name="provider_matricule" xml:space="preserve">
+    <value>Registration Number</value>
+  </data>
+  <data name="provider_name" xml:space="preserve">
+    <value>Provider name</value>
+  </data>
+  <data name="provider_phone" xml:space="preserve">
+    <value>Phone number</value>
+  </data>
+  <data name="provider_second_email" xml:space="preserve">
+    <value>Secondry E-mail</value>
+  </data>
+  <data name="providers" xml:space="preserve">
+    <value>Providers</value>
+  </data>
 </root>


### PR DESCRIPTION
#158
Replaced `RadzenToggleButton` with `RadzenSwitch` for the `provider.Constructeur` property in `EditProvider.razor`, enhancing the UI. Added a top margin to the `RadzenRow`.

Updated `SharedResource.en.resx` with new English translations for provider-related terms, including "Address," "Code," "Constructor," "Email," and others.